### PR TITLE
Delete Flash Message Link

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -30,8 +30,7 @@ class CartsController < ApplicationController
     @cart.delete_item(item.id)
     session[:cart] = @cart.contents
 
-    flash[:notice] = "You have successfully removed #{item.title} from the cart."
+    flash[:notice] = "You have successfully removed <a href='/items/#{item.id}'>#{item.title}</a> from the cart."
     redirect_to cart_path
   end
-
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -29,7 +29,6 @@ class CartsController < ApplicationController
     item = Item.find(params[:item_id])
     @cart.delete_item(item.id)
     session[:cart] = @cart.contents
-
     flash[:notice] = "You have successfully removed <a href='/items/#{item.id}'>#{item.title}</a> from the cart."
     redirect_to cart_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,16 @@
 class ItemsController < ApplicationController
+  before_action :find_item, only: [:show]
 
   def index
     @items = Item.all
   end
 
+  def show
+  end
+
+  private
+
+  def find_item
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,11 +1,11 @@
 <div class="container text-center">
   <div class="row">
-    <div class="col-md-12 item-<%= item.id %>">
-      <img class="img-responsive item-images img-thumbnail" src="<%= item.image_path %>" alt="item image"><br/>
-      <%= item.title %><br/>
-      <%= item.description %><br/>
-      <%= number_to_currency(item.price, :unit => "$") %><br/><br/>
-      <%= button_to "Add to Cart", carts_path(item_id: item.id), class: "btn btn-danger" %><br/><br/><br/>
+    <div class="col-md-12 item-<%= @item.id %>">
+      <img class="img-responsive item-images img-thumbnail" src="<%= @item.image_path %>" alt="item image"><br/>
+      <%= @item.title %><br/>
+      <%= @item.description %><br/>
+      <%= number_to_currency(@item.price, :unit => "$") %><br/><br/>
+      <%= button_to "Add to Cart", carts_path(item_id: @item.id), class: "btn btn-danger" %><br/><br/><br/>
     </div>
   </div>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,11 @@
+<div class="container text-center">
+  <div class="row">
+    <div class="col-md-12 item-<%= item.id %>">
+      <img class="img-responsive item-images img-thumbnail" src="<%= item.image_path %>" alt="item image"><br/>
+      <%= item.title %><br/>
+      <%= item.description %><br/>
+      <%= number_to_currency(item.price, :unit => "$") %><br/><br/>
+      <%= button_to "Add to Cart", carts_path(item_id: item.id), class: "btn btn-danger" %><br/><br/><br/>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
   </nav>
 </header>
   <% flash.each do |key, value| %>
-  <div class="alert alert-<%= key %> alert-success"><h3 class="flash_header"> <%= value %> </h3></div>
+  <div class="alert alert-<%= key %> alert-success"><h3 class="flash_header"><%= sanitize(value) %> </h3></div>
   <% end %>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
               <li><a href="/pure%20evil">Pure Evil</a></li>
             </ul>
           </li>
-          <li class="cart"><%= link_to "cart" do %>
+          <li class="cart"><%= link_to cart_path do %>
             <span class="glyphicon glyphicon-shopping-cart"></span> Cart
           <% end %></li>
           <li><a href="#"><span class="glyphicon glyphicon-log-in"></span> Login</a></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :items, only: [:index]
+  resources :items, only: [:index, :show]
 
   resources :carts, only: [:create]
 

--- a/spec/features/visitor_deletes_item_from_cart_spec.rb
+++ b/spec/features/visitor_deletes_item_from_cart_spec.rb
@@ -24,8 +24,8 @@ RSpec.feature "Visitor deletes item from cart" do
 
     expect(current_path).to eq(cart_path)
     expect(page).to have_content("You have successfully removed #{item_1.title} from the cart.")
+    expect(page).to have_link item_1.title, href: item_path(item_1)
     expect(page).to_not have_content(item_1.description)
     expect(page).to have_content(item_2.title)
   end
-
 end

--- a/spec/features/visitor_deletes_item_from_cart_spec.rb
+++ b/spec/features/visitor_deletes_item_from_cart_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Visitor deletes item from cart" do
     within(".item-#{item_1.id}") do
       click_button "Delete"
     end
-
+    save_and_open_page
     expect(current_path).to eq(cart_path)
     expect(page).to have_content("You have successfully removed #{item_1.title} from the cart.")
     expect(page).to have_link item_1.title, href: item_path(item_1)

--- a/spec/features/visitor_deletes_item_from_cart_spec.rb
+++ b/spec/features/visitor_deletes_item_from_cart_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Visitor deletes item from cart" do
     within(".item-#{item_1.id}") do
       click_button "Delete"
     end
-    save_and_open_page
+    
     expect(current_path).to eq(cart_path)
     expect(page).to have_content("You have successfully removed #{item_1.title} from the cart.")
     expect(page).to have_link item_1.title, href: item_path(item_1)

--- a/spec/features/visitor_visits_item_show_page_spec.rb
+++ b/spec/features/visitor_visits_item_show_page_spec.rb
@@ -1,5 +1,5 @@
-RSpec.feature "when a visitor visits items index" do
-  scenario "they can see all items" do
+RSpec.feature "when a visitor visits individual item page" do
+  scenario "they see only that item" do
     item_1, item_2 = create_list(:item, 2)
 
     visit item_path(item_2)

--- a/spec/features/visitor_visits_item_show_page_spec.rb
+++ b/spec/features/visitor_visits_item_show_page_spec.rb
@@ -1,0 +1,15 @@
+RSpec.feature "when a visitor visits items index" do
+  scenario "they can see all items" do
+    item_1, item_2 = create_list(:item, 2)
+
+    visit item_path(item_2)
+
+    expect(page).to_not have_content(item_1.title)
+    expect(page).to have_content(item_2.title)
+    expect(page).to_not have_content(item_1.description)
+    expect(page).to have_content(item_2.description)
+    expect(page).to_not have_content(item_1.price)
+    expect(page).to have_content(item_2.price)
+    expect(page).to have_css("img", count:1)
+  end
+end


### PR DESCRIPTION
**Changes:**
- adds item title link to delete flash message
- adds item show page and test (since that's where the link needs to go)
- modifies link_to for cart in navbar  - there was some buggy behavior when you clicked on cart from the item show page, it would direct back to items#show and error out when it couldn't find an item with id "cart". Changing to cart_path seemed to fix it.