### PR TITLE
Mhd sad path for users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       redirect_to dashboard_path
     else
+      flash[:notice] = "Username doth taken or passwordeth no valid, please retryith"
       render :new
     end
   end

--- a/spec/features/authenticated/user_logs_in_to_site_spec.rb
+++ b/spec/features/authenticated/user_logs_in_to_site_spec.rb
@@ -25,4 +25,38 @@ RSpec.feature "User logs in to site" do
 
     expect(page).to have_link("Logout")
   end
-end
+
+  scenario "user receives error when inputs invalid password" do
+      items = create_list(:item, 3)
+      user = create(:user)
+
+      visit "/"
+
+      expect(page).to have_content("Login")
+
+      click_link("Login")
+
+      fill_in "session_username", with: user.username
+      fill_in "session_password", with: "bad password"
+      click_button("Log In")
+
+      expect(page).to have_content("The password thou hast provided doeth not match. Please endeavour once more or createth thine account.")
+    end
+
+    scenario "enters invalid username" do
+      items = create_list(:item, 3)
+      user = create(:user)
+
+      visit "/"
+
+      expect(page).to have_content("Login")
+
+      click_link("Login")
+
+      fill_in "session_username", with: "bad username"
+      fill_in "session_password", with: user.password
+      click_button("Log In")
+
+      expect(page).to have_content("We haveth no known user with that name. Please endeavour once more or createth thine account.")
+    end
+  end

--- a/spec/features/unauthenticated/user_can_create_new_account_spec.rb
+++ b/spec/features/unauthenticated/user_can_create_new_account_spec.rb
@@ -28,4 +28,74 @@ RSpec.feature "User can create new account" do
 
     expect(page).to have_link("Logout")
   end
+
+  scenario "user enters unavailable username" do
+    create_list(:item, 3)
+    user = create(:user, username: "sauron")
+
+    visit(root_path)
+
+    expect(page).to have_link("Login")
+
+    click_link("Login")
+
+    expect(current_path).to eq(login_path)
+
+    click_link("Create Account")
+
+    fill_in "user[username]", with: "sauron"
+    fill_in "user[password]", with: "Bilbo123"
+    fill_in "user[password_confirmation]", with: "Bilbo123"
+
+    click_button("Signeth Thou Up")
+
+    expect(page).to have_content("Username doth taken or passwordeth no valid, please retryith")
+    expect(page).to_not have_content("Signed in as sauron")
+  end
+
+  scenario "user enters invalid password" do
+    create_list(:item, 3)
+
+    visit(root_path)
+
+    expect(page).to have_link("Login")
+
+    click_link("Login")
+
+    expect(current_path).to eq(login_path)
+
+    click_link("Create Account")
+
+    fill_in "user[username]", with: "sauron"
+    fill_in "user[password]", with: ""
+    fill_in "user[password_confirmation]", with: ""
+
+    click_button("Signeth Thou Up")
+
+    expect(page).to have_content("Username doth taken or passwordeth no valid, please retryith")
+    expect(page).to_not have_content("Signed in as sauron")
+  end
+
+  scenario "user enters incorrect password confirmation" do
+    create_list(:item, 3)
+
+    visit(root_path)
+
+    expect(page).to have_link("Login")
+
+    click_link("Login")
+
+    expect(current_path).to eq(login_path)
+
+    click_link("Create Account")
+
+    fill_in "user[username]", with: "sauron"
+    fill_in "user[password]", with: "Bilbo123"
+    fill_in "user[password_confirmation]", with: "not bilbo123"
+
+    click_button("Signeth Thou Up")
+
+    expect(page).to have_content("Username doth taken or passwordeth no valid, please retryith")
+    expect(page).to_not have_content("Signed in as sauron")
+  end
 end


### PR DESCRIPTION
Sad path testing added for user authentication:
-errors thrown if current user logs in with invalid username and/or password
-errors thrown if guest tries to create account with invalid/blank username and/or password
-errors thrown if guest fails to confirm password